### PR TITLE
feat: enable pair migration from factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.8.0
+
+* [9ac5067](https://github.com/terraswap/terraswap/pull/55/commits/9ac50670e8bd20e00950e00b66a687e0a9d4fef9) Support to migrate pair
+
 # 2.7.0
 
 * [4e3e80e](https://github.com/terraswap/terraswap/pull/52/commits/4e3e80ea04b44e0396f8d03c306adf096a864573) Add native token decimals

--- a/terraswap_factory/Cargo.toml
+++ b/terraswap_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-factory"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Terraform Labs, PTE.", "DELIGHT LABS", "Kerber0x <kerber0x@protonmail.com>"]
 edition = "2018"
 description = "A Terraswap factory contract - auto pair contract generator and also directory for all pairs"
@@ -24,13 +24,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
-cw-storage-plus = { version = "0.13.4" }
+cw-storage-plus = { version = "0.14.0" }
 schemars = "0.8.10"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 protobuf = { version = "2", features = ["with-bytes"] }
-cw20 = { version = "0.13.4" }
-terraswap = { version = "2.7.0", path = "../../../../packages/terraswap"}
-white-whale = { version = "0.1.0", path = "../../../../packages/white-whale"}
+cw20 = { version = "0.14.0" }
+cw2 = { version = "0.14.0" }
+terraswap = { version = "2.8.0", path = "../../../../packages/terraswap"}
+white-whale = { version = "1.0.0", path = "../../../../packages/white-whale"}
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/terraswap_factory/schema/execute_msg.json
+++ b/terraswap_factory/schema/execute_msg.json
@@ -3,7 +3,7 @@
   "title": "ExecuteMsg",
   "oneOf": [
     {
-      "description": "UpdateConfig update relevant code IDs",
+      "description": "Updates contract's config, i.e. relevant code_ids, fee_collector address and owner",
       "type": "object",
       "required": [
         "update_config"
@@ -46,7 +46,7 @@
       "additionalProperties": false
     },
     {
-      "description": "CreatePair instantiates pair contract",
+      "description": "Instantiates pair contract",
       "type": "object",
       "required": [
         "create_pair"
@@ -77,6 +77,7 @@
       "additionalProperties": false
     },
     {
+      "description": "Adds native token info to the contract so it can instantiate pair contracts that include it",
       "type": "object",
       "required": [
         "add_native_token_decimals"
@@ -95,6 +96,35 @@
               "minimum": 0.0
             },
             "denom": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Migrates a pair contract to a given code_id",
+      "type": "object",
+      "required": [
+        "migrate_pair"
+      ],
+      "properties": {
+        "migrate_pair": {
+          "type": "object",
+          "required": [
+            "contract"
+          ],
+          "properties": {
+            "code_id": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "contract": {
               "type": "string"
             }
           }

--- a/terraswap_factory/src/commands.rs
+++ b/terraswap_factory/src/commands.rs
@@ -6,7 +6,9 @@ use cosmwasm_std::{
     SubMsg, WasmMsg,
 };
 use terraswap::asset::AssetInfo;
-use terraswap::pair::{InstantiateMsg as PairInstantiateMsg, PoolFee};
+use terraswap::pair::{
+    InstantiateMsg as PairInstantiateMsg, MigrateMsg as PairMigrateMsg, PoolFee,
+};
 use terraswap::querier::query_balance;
 
 /// Updates the contract's [Config]
@@ -157,4 +159,23 @@ pub fn add_native_token_decimals(
         ("denom", &denom),
         ("decimals", &decimals.to_string()),
     ]))
+}
+
+pub fn execute_migrate_pair(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    contract: String,
+    code_id: Option<u64>,
+) -> StdResult<Response> {
+    let config: Config = CONFIG.load(deps.storage)?;
+    let code_id = code_id.unwrap_or(config.pair_code_id);
+
+    Ok(
+        Response::new().add_message(CosmosMsg::Wasm(WasmMsg::Migrate {
+            contract_addr: contract,
+            new_code_id: code_id,
+            msg: to_binary(&PairMigrateMsg {})?,
+        })),
+    )
 }

--- a/terraswap_pair/Cargo.toml
+++ b/terraswap_pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-pair"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Terraform Labs, PTE.", "DELIGHT LABS", "Kerber0x <kerber0x@protonmail.com>"]
 edition = "2018"
 description = "A Terraswap pair contract"
@@ -23,18 +23,18 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw2 = { version = "0.13.4" }
-cw20 = { version = "0.13.4" }
+cw2 = { version = "0.14.0" }
+cw20 = { version = "0.14.0" }
 cosmwasm-std = { version = "1.0.0" }
-cw-storage-plus = { version = "0.13.4" }
+cw-storage-plus = { version = "0.14.0" }
 integer-sqrt = "0.1.5"
 schemars = "0.8.10"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
 protobuf = { version = "2", features = ["with-bytes"] }
 cosmwasm-bignumber = { git = "https://github.com/terra-money/terra-cosmwasm", branch = "feature/wasm-1.0" }
-terraswap = { version = "2.7.0", path = "../../../../packages/terraswap"}
-white-whale = { version = "0.1.0", path = "../../../../packages/white-whale" }
+terraswap = { version = "2.8.0", path = "../../../../packages/terraswap"}
+white-whale = { version = "1.0.0", path = "../../../../packages/white-whale" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/terraswap_pair/src/contract.rs
+++ b/terraswap_pair/src/contract.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
     to_binary, Binary, CanonicalAddr, Deps, DepsMut, Env, MessageInfo, Reply, ReplyOn, Response,
     StdError, StdResult, Storage, SubMsg, Uint128, WasmMsg,
 };
+use cw2::set_contract_version;
 use cw20::MinterResponse;
 use cw_storage_plus::Item;
 use protobuf::Message;
@@ -19,6 +20,10 @@ use crate::state::{
 };
 use crate::{commands, queries};
 
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:terraswap-pair";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 const INSTANTIATE_REPLY_ID: u64 = 1;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -28,6 +33,8 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     let pair_info: &PairInfoRaw = &PairInfoRaw {
         contract_addr: deps.api.addr_canonicalize(env.contract.address.as_str())?,
         liquidity_token: CanonicalAddr::from(vec![]),
@@ -226,6 +233,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     Ok(Response::default())
 }

--- a/terraswap_router/Cargo.toml
+++ b/terraswap_router/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "terraswap-router"
-version = "0.1.0"
-authors = ["Terraform Labs, PTE.", "DELIGHT LABS"]
+version = "1.0.0"
+authors = ["Terraform Labs, PTE.", "DELIGHT LABS", "Kerber0x <kerber0x@protonmail.com>"]
 edition = "2018"
 description = "A Terraswap router contract - provides multi-step operations to facilitate single sign operation"
 license = "Apache-2.0"
@@ -23,10 +23,11 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cw20 = { version = "0.13.4" }
+cw2 = { version = "0.14.0" }
+cw20 = { version = "0.14.0" }
 cosmwasm-std = { version = "1.0.0" }
-terraswap = { version = "2.7.0", path = "../../../../packages/terraswap"}
-cw-storage-plus = { version = "0.13.4"}
+terraswap = { version = "2.8.0", path = "../../../../packages/terraswap"}
+cw-storage-plus = { version = "0.14.0"}
 integer-sqrt = "0.1.5"
 schemars = "0.8.10"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }

--- a/terraswap_router/src/contract.rs
+++ b/terraswap_router/src/contract.rs
@@ -9,6 +9,7 @@ use cosmwasm_std::{
 use crate::operations::execute_swap_operation;
 use crate::state::{Config, CONFIG};
 
+use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
 use std::collections::HashMap;
 use terraswap::asset::{Asset, AssetInfo, PairInfo};
@@ -19,6 +20,10 @@ use terraswap::router::{
     SimulateSwapOperationsResponse, SwapOperation,
 };
 
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:terraswap-router";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
@@ -26,6 +31,8 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     CONFIG.save(
         deps.storage,
         &Config {
@@ -409,6 +416,8 @@ fn test_invalid_operations() {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     Ok(Response::default())
 }

--- a/terraswap_token/Cargo.toml
+++ b/terraswap_token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terraswap-token"
-version = "0.0.0"
+version = "1.0.0"
 authors = ["Terraform Labs, PTE.", "DELIGHT LABS"]
 edition = "2018"
 description = "Backward compatible implementation of a CosmWasm-20 compliant token"
@@ -19,15 +19,15 @@ library = []
 
 [dependencies]
 cw0 = { version = "0.10.3" } 
-cw2 = { version = "0.13.4" }
-cw20 = {version = "0.13.4"}
-cw20-base = {version = "0.13.4", features = ["library"]}
-cw-storage-plus  = { version = "0.13.4" }
+cw2 = { version = "0.14.0" }
+cw20 = {version = "0.14.0"}
+cw20-base = {version = "0.14.0", features = ["library"]}
+cw-storage-plus  = { version = "0.14.0" }
 cosmwasm-std = { version = "1.0.0" }
 schemars = "0.8.10"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
-terraswap = { version = "2.7.0", path = "../../../../packages/terraswap"}
+terraswap = { version = "2.8.0", path = "../../../../packages/terraswap"}
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/terraswap_token/schema/cw20_execute_msg.json
+++ b/terraswap_token/schema/cw20_execute_msg.json
@@ -260,6 +260,27 @@
       "additionalProperties": false
     },
     {
+      "description": "Only with the \"mintable\" extension. The current minter may set a new minter. Setting the minter to None will remove the token's minter forever.",
+      "type": "object",
+      "required": [
+        "update_minter"
+      ],
+      "properties": {
+        "update_minter": {
+          "type": "object",
+          "properties": {
+            "new_minter": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Only with the \"marketing\" extension. If authorized, updates marketing metadata. Setting None/null for any of these will leave it unchanged. Setting Some(\"\") will clear this field on the contract storage",
       "type": "object",
       "required": [

--- a/terraswap_token/schema/query_msg.json
+++ b/terraswap_token/schema/query_msg.json
@@ -110,6 +110,41 @@
       "additionalProperties": false
     },
     {
+      "description": "Only with \"enumerable\" extension (and \"allowances\") Returns all allowances this spender has been granted. Supports pagination. Return type: AllSpenderAllowancesResponse.",
+      "type": "object",
+      "required": [
+        "all_spender_allowances"
+      ],
+      "properties": {
+        "all_spender_allowances": {
+          "type": "object",
+          "required": [
+            "spender"
+          ],
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "spender": {
+              "type": "string"
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Only with \"enumerable\" extension Returns all accounts that have balances. Supports pagination. Return type: AllAccountsResponse.",
       "type": "object",
       "required": [


### PR DESCRIPTION
## Summary of changes

<Describe summary of major changes here>

This PR adopts the Terraswap release 2.8.0, supporting pair migration from the factory.
https://github.com/terraswap/terraswap/pull/55/commits/9ac50670e8bd20e00950e00b66a687e0a9d4fef9

Also, update all contracts versions and dependencies, getting ready for the release.

## Report of required housekeeping

- [ ] Github issue OR spec proposal link
- [ ] Wrote tests
- [ ] Added a relevant changelog entry to CHANGELOG.md

----

## (FOR ADMIN) Before merging

- [ ] Added appropriate labels to PR
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" (coding standards)
- [ ] Confirm added tests are consistent with the intended behavior of changes
- [ ] Ensure all tests pass
